### PR TITLE
feat: Add omitIdComments option to Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for opting out of emitting the `@see` directives in schema doc comments through the `omitIdComments` option. By default, these tags _will_ be emitted to preserve backwards-compatibility. To omit these comments, `omitIdComments: true` can be specified as an option.
 
 ## [1.4.1] - 2021-04-05
 ### Fixed

--- a/src/nodes.test.ts
+++ b/src/nodes.test.ts
@@ -1,0 +1,26 @@
+import { SchemaNode, SchemaNodeOptions } from './nodes';
+import type { CoreSchemaMetaSchema } from './schema';
+
+describe('SchemaNode', () => {
+  it('will only emit a `@see` directive when requested', () => {
+    const schema: CoreSchemaMetaSchema = {
+      type: 'boolean',
+      $id: 'file://path',
+    };
+
+    const node = new SchemaNode('file://path', 'file://path', schema, schema as SchemaNodeOptions);
+
+    expect(node.provideDocs({ emitSeeDirective: false })).toMatchInlineSnapshot(`undefined`);
+    expect(node.provideDocs({ emitSeeDirective: true })).toMatchInlineSnapshot(`
+      Object {
+        "description": "",
+        "tags": Array [
+          Object {
+            "tagName": "see",
+            "text": "file://path",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -13,6 +13,9 @@ import { JSONSchema7, JSONSchema7Definition, JSONSchema7Type, JSONSchema7TypeNam
 
 export type AnyType = 'any' | 'JSONValue' | 'unknown';
 
+export interface IDocEmitOptions {
+  emitSeeDirective?: boolean;
+}
 export interface ITypingContext {
   anyType: AnyType;
   getNameForReference(ref: IReference): string;
@@ -25,7 +28,7 @@ export interface ISchemaNode<T extends JSONSchema7Definition = JSONSchema7Defini
   readonly uri: string;
 
   provideWriterFunction(ctx: ITypingContext): WriterFunction;
-  provideDocs(): OptionalKind<JSDocStructure> | undefined;
+  provideDocs(options?: IDocEmitOptions): OptionalKind<JSDocStructure> | undefined;
 }
 
 export enum SchemaNodeKind {
@@ -163,7 +166,7 @@ export class BooleanSchemaNode extends BaseSchemaNode<boolean> {
 export class SchemaNode extends BaseSchemaNode<JSONSchema7, SchemaNodeOptions> {
   readonly kind = SchemaNodeKind.Schema;
 
-  provideDocs() {
+  provideDocs(options?: IDocEmitOptions) {
     const lines: string[] = [];
     const tags: OptionalKind<JSDocTagStructure>[] = [];
 
@@ -175,7 +178,7 @@ export class SchemaNode extends BaseSchemaNode<JSONSchema7, SchemaNodeOptions> {
       lines.push(this.schema.description);
     }
 
-    if (this.schema.$id) {
+    if (options?.emitSeeDirective && this.schema.$id) {
       tags.push({ tagName: 'see', text: this.schema.$id });
     }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -28,6 +28,12 @@ interface ParserCompileOptions {
   anyType?: AnyType;
 
   /**
+   * Skip emitting a `@see` directive when generating doc comments on schemas having
+   * an `$id` property.
+   */
+  omitIdComments?: boolean;
+
+  /**
    * Declaration options for the top-level schemas in each added schema file.
    */
   topLevel?: ParserCompileTypeOptions;


### PR DESCRIPTION
## Description

Add support for the `omitIdComments` option to the `Parser` constructor. When truthy, schemas having an `$id` property will no longer emit `@see` doc comment directives.