### PR TITLE
Fix incorrect property name escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Change `hasAnyProperty` type argument to extend `{}` so that TypeScript can understand that the iteration protocol is supported over properties.
+- Detect `"properties"` keys that are invalid JavaScript identifier names and escape them in the generated code.
+  
+  For example, the property `"app.prop"` will no longer produce invalid types and will instead be encoded as `["app.prop"]`.
+
+  Fixes #7.
 
 ## [1.5.0] - 2022-08-31
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
+        "is-valid-variable": "^1.0.1",
         "ts-morph": "^8.1.1"
       },
       "devDependencies": {
@@ -4389,6 +4390,11 @@
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
+    },
+    "node_modules/is-valid-variable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-valid-variable/-/is-valid-variable-1.0.1.tgz",
+      "integrity": "sha512-ucsrYzt8kcgu2CAOFFWSfOTwa+vPNzQHK1RL6RooSkwozJ92e9wl4cyG/GLDeuNEVj56kvuNZGCR7eSkzrhudg=="
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -12449,6 +12455,11 @@
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
+    },
+    "is-valid-variable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-valid-variable/-/is-valid-variable-1.0.1.tgz",
+      "integrity": "sha512-ucsrYzt8kcgu2CAOFFWSfOTwa+vPNzQHK1RL6RooSkwozJ92e9wl4cyG/GLDeuNEVj56kvuNZGCR7eSkzrhudg=="
     },
     "is-windows": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dist"
   ],
   "dependencies": {
+    "is-valid-variable": "^1.0.1",
     "ts-morph": "^8.1.1"
   },
   "devDependencies": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -108,6 +108,39 @@ describe('Definition generation', () => {
     `);
   });
 
+  it('will correctly quote properties with special characters', () => {
+    // See: https://github.com/ggoodman/json-schema-to-dts/issues/7
+    const parser = new Parser();
+    parser.addSchema('urn:test', {
+      $id: 'urn:test',
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'The name of an object',
+        },
+        'app.prop': {
+          type: 'null',
+        },
+      },
+    });
+
+    const result = parser.compile();
+
+    expect(result.text).toMatchInlineSnapshot(`
+      "type JSONPrimitive = boolean | null | number | string;
+      type JSONValue = JSONPrimitive | JSONValue[] | {
+          [key: string]: JSONValue;
+      };
+      export type Test = {
+          /** The name of an object */
+          name?: string;
+          [\\"app.prop\\"]?: null;
+      };
+      "
+    `);
+  });
+
   describe('will produce schemas that reflect the selected anyType', () => {
     it('when anyType is unspecified', () => {
       const parser = new Parser();

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -1,3 +1,4 @@
+import isValidVariable from 'is-valid-variable';
 import {
   CodeBlockWriter,
   IndexSignatureDeclarationStructure,
@@ -143,7 +144,8 @@ export interface SchemaNodeOptions {
 }
 
 abstract class BaseSchemaNode<TSchema extends JSONSchema7Definition, TOptions = undefined>
-  implements ISchemaNode<TSchema> {
+  implements ISchemaNode<TSchema>
+{
   abstract readonly kind: SchemaNodeKind;
 
   constructor(
@@ -362,10 +364,11 @@ export class SchemaNode extends BaseSchemaNode<JSONSchema7, SchemaNodeOptions> {
 
         const typeWriter = node.provideWriterFunction(ctx);
         const docs = node.provideDocs();
+        const safeName = propertyNameRequiresQuoting(name) ? `[${JSON.stringify(name)}]` : name;
 
         properties.push({
           docs: docs ? [docs] : undefined,
-          name,
+          name: safeName,
           hasQuestionToken: !required.has(name),
           type: typeWriter,
         });
@@ -459,4 +462,8 @@ function createUnionTypeWriterFunction(options: WriterFunction[]): WriterFunctio
     writerFn(writer);
     writer.write(')');
   };
+}
+
+function propertyNameRequiresQuoting(name: string): boolean {
+  return !isValidVariable(name);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,7 @@
     "esModuleInterop": true,
     "importHelpers": true,
     "incremental": true,
-    "lib": [
-      "esnext"
-    ],
+    "lib": ["esnext"],
     "module": "CommonJS",
     "moduleResolution": "Node",
     "noErrorTruncation": true,
@@ -22,9 +20,5 @@
     "strict": true,
     "target": "ES2018"
   },
-  "include": [
-    "src",
-    "types",
-    "old"
-  ]
+  "include": ["src", "types", "old"]
 }

--- a/types/is-valid-variable.d.ts
+++ b/types/is-valid-variable.d.ts
@@ -1,0 +1,4 @@
+declare module 'is-valid-variable' {
+  function isValidVariable(str: string): boolean;
+  export = isValidVariable;
+}


### PR DESCRIPTION
### Fixed
- Detect `"properties"` keys that are invalid JavaScript identifier names and escape them in the generated code.
  
  For example, the property `"app.prop"` will no longer produce invalid types and will instead be encoded as `["app.prop"]`.

  Fixes #7.
